### PR TITLE
Use public HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git + git@github.com:Simon-He95/identify-image.git"
+    "url": "git+https://github.com/Simon-He95/identify-image.git"
   },
   "bugs": {
     "url": "https://github.com/Simon-He95/identify-image/issues"


### PR DESCRIPTION
This updates the npm package repository metadata to use a public HTTPS Git URL instead of the current SSH/SCP-style URL.

Current value:

```json
"repository": {
  "type": "git",
  "url": "git + git@github.com:Simon-He95/identify-image.git"
}
```

Updated value:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/Simon-He95/identify-image.git"
}
```

This is a metadata-only change:
- no runtime code changes
- no dependency changes
- no version or entrypoint changes

Validation:
- confirmed the current `package.json` fails an assertion expecting the public HTTPS repository URL
- confirmed this branch passes the same assertion
- confirmed the compare contains one commit and only changes `package.json`